### PR TITLE
feat: add two-stage hybrid mystic solver (diffev2 + fmin_powell)

### DIFF
--- a/src/bssunfold/core/__init__.py
+++ b/src/bssunfold/core/__init__.py
@@ -64,8 +64,8 @@ from .unfold_mlem_odl import unfold_mlem_odl
 from .unfold_mlem_stop import solve_mlem_stop, unfold_mlem_stop
 from .unfold_mystic import (
     solve_mystic,
-    unfold_mystic,
     solve_mystic_hybrid,
+    unfold_mystic,
     unfold_mystic_hybrid,
 )
 from .unfold_nsduaz import (

--- a/src/bssunfold/core/__init__.py
+++ b/src/bssunfold/core/__init__.py
@@ -62,7 +62,12 @@ from .unfold_mcmc import solve_bayesian_mcmc, unfold_mcmc
 from .unfold_mlem import solve_mlem, unfold_mlem
 from .unfold_mlem_odl import unfold_mlem_odl
 from .unfold_mlem_stop import solve_mlem_stop, unfold_mlem_stop
-from .unfold_mystic import solve_mystic, unfold_mystic
+from .unfold_mystic import (
+    solve_mystic,
+    unfold_mystic,
+    solve_mystic_hybrid,
+    unfold_mystic_hybrid,
+)
 from .unfold_nsduaz import (
     builtin_catalogue,
     select_catalogue_initial,
@@ -108,6 +113,7 @@ __all__ = [
     "solve_mlem",
     "solve_qpsolvers",
     "solve_mystic",
+    "solve_mystic_hybrid",
     "solve_genetic",
     "solve_doroshenko",
     "solve_kaczmarz",
@@ -160,6 +166,7 @@ __all__ = [
     "unfold_mlem",
     "unfold_qpsolvers",
     "unfold_mystic",
+    "unfold_mystic_hybrid",
     "unfold_genetic",
     "unfold_doroshenko",
     "unfold_kaczmarz",

--- a/src/bssunfold/core/detector.py
+++ b/src/bssunfold/core/detector.py
@@ -84,6 +84,7 @@ from .unfold_mlem import unfold_mlem as unfold_mlem_impl
 from .unfold_mlem_odl import unfold_mlem_odl as unfold_mlem_odl_impl
 from .unfold_mlem_stop import unfold_mlem_stop as unfold_mlem_stop_impl
 from .unfold_mystic import unfold_mystic as unfold_mystic_impl
+from .unfold_mystic import unfold_mystic_hybrid as unfold_mystic_hybrid_impl
 from .unfold_nsduaz import unfold_nsduaz as unfold_nsduaz_impl
 from .unfold_odl_advanced import (
     unfold_odl_douglas_rachford as unfold_odl_douglas_rachford_impl,
@@ -882,6 +883,117 @@ class Detector:
             solver=solver,
             maxiter=maxiter,
             maxfun=maxfun,
+            calculate_errors=calculate_errors,
+            noise_level=noise_level,
+            n_montecarlo=n_montecarlo,
+            save_result=save_result,
+            regularization_method=regularization_method,
+            noise_var=noise_var,
+            smoothness_order=smoothness_order,
+            smoothness_weight=smoothness_weight,
+            random_state=random_state,
+        )
+
+    def unfold_mystic_hybrid(
+        self,
+        readings: Dict[str, float],
+        initial_spectrum: Optional[np.ndarray] = None,
+        regularization: float = 1e-4,
+        norm: int = 2,
+        global_solver: str = "diffev2",
+        local_solver: str = "fmin_powell",
+        global_maxiter: Optional[int] = None,
+        global_maxfun: Optional[int] = None,
+        local_maxiter: Optional[int] = None,
+        local_maxfun: Optional[int] = None,
+        npop: Optional[int] = None,
+        calculate_errors: bool = False,
+        noise_level: float = 0.01,
+        n_montecarlo: int = 100,
+        save_result: bool = False,
+        regularization_method: str = "manual",
+        noise_var: Optional[float] = None,
+        smoothness_order: int = 0,
+        smoothness_weight: float = 1.0,
+        random_state: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Two-stage hybrid unfolding: global search + local refinement.
+
+        Stage 1 uses a population-based solver (``diffev2`` by default)
+        with automatically derived bounds to robustly locate the basin of
+        the global minimum.  Stage 2 feeds that result as ``x0`` into a
+        local direct-search solver (``fmin_powell`` by default) for precise
+        final convergence.
+
+        Parameters
+        ----------
+        readings : Dict[str, float]
+            Detector readings.
+        initial_spectrum : np.ndarray, optional
+            Initial spectrum guess for the global stage.
+        regularization : float, optional
+            Regularization parameter, default: 1e-4.
+        norm : int, optional
+            Norm type (1 for L1, 2 for L2), default: 2.
+        global_solver : str, optional
+            Population-based solver for stage 1 (``'diffev'`` or
+            ``'diffev2'``), default: ``'diffev2'``.
+        local_solver : str, optional
+            Local solver for stage 2 (``'fmin'`` or ``'fmin_powell'``),
+            default: ``'fmin_powell'``.
+        global_maxiter : int, optional
+            Maximum iterations for the global stage (default: 200).
+        global_maxfun : int, optional
+            Maximum function evaluations for the global stage.
+        local_maxiter : int, optional
+            Maximum iterations for the local stage (default: 2000).
+        local_maxfun : int, optional
+            Maximum function evaluations for the local stage.
+        npop : int, optional
+            Population size for the global stage.
+        calculate_errors : bool, optional
+            If True, calculate Monte-Carlo uncertainty, default: False.
+        noise_level : float, optional
+            Noise level for Monte-Carlo, default: 0.01.
+        n_montecarlo : int, optional
+            Number of Monte-Carlo samples, default: 100.
+        save_result : bool, optional
+            Save result to history, default: False.
+        regularization_method : str, optional
+            Method for selecting regularization parameter.
+            Options: 'manual', 'cosine', 'gcv', 'lcurve', 'dp'.
+        noise_var : float, optional
+            Noise variance for discrepancy principle ('dp' method).
+        smoothness_order : int, optional
+            Smoothness constraint order (0, 1, or 2), default: 0.
+        smoothness_weight : float, optional
+            Weight for smoothness term, default: 1.0.
+        random_state : int, optional
+            Random seed for reproducibility.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Unfolding results including spectrum, residuals, and metadata.
+        """
+        return unfold_mystic_hybrid_impl(
+            detector_names=self.detector_names,
+            n_energy_bins=self.n_energy_bins,
+            E_MeV=self.E_MeV,
+            sensitivities=self.sensitivities,
+            cc_icrp116=self._get_interpolated_cc(),
+            save_result_callback=self._save_result,
+            readings=readings,
+            initial_spectrum=initial_spectrum,
+            regularization=regularization,
+            norm=norm,
+            global_solver=global_solver,
+            local_solver=local_solver,
+            global_maxiter=global_maxiter,
+            global_maxfun=global_maxfun,
+            local_maxiter=local_maxiter,
+            local_maxfun=local_maxfun,
+            npop=npop,
             calculate_errors=calculate_errors,
             noise_level=noise_level,
             n_montecarlo=n_montecarlo,

--- a/src/bssunfold/core/unfold_cascade.py
+++ b/src/bssunfold/core/unfold_cascade.py
@@ -63,6 +63,7 @@ METHOD_DISPATCH: Dict[str, str] = {
     "kaczmarz": "unfold_kaczmarz",
     "genetic": "unfold_genetic",
     "mystic": "unfold_mystic",
+    "mystic_hybrid": "unfold_mystic_hybrid",
     "scip": "unfold_scip",
     "docplex": "unfold_docplex",
     "epic": "unfold_epic",

--- a/src/bssunfold/core/unfold_combined.py
+++ b/src/bssunfold/core/unfold_combined.py
@@ -77,7 +77,7 @@ def unfold_combined(
     from .unfold_mapem import unfold_mapem
     from .unfold_mlem import unfold_mlem
     from .unfold_mlem_odl import unfold_mlem_odl
-    from .unfold_mystic import unfold_mystic
+    from .unfold_mystic import unfold_mystic, unfold_mystic_hybrid
     from .unfold_osem import unfold_osem
     from .unfold_qpsolvers import unfold_qpsolvers
     from .unfold_sandii import unfold_sandii
@@ -115,6 +115,7 @@ def unfold_combined(
             "mlem_odl": unfold_mlem_odl,
             "qpsolvers": unfold_qpsolvers,
             "mystic": unfold_mystic,
+            "mystic_hybrid": unfold_mystic_hybrid,
             "genetic": unfold_genetic,
             "doroshenko": unfold_doroshenko,
             "kaczmarz": unfold_kaczmarz,

--- a/src/bssunfold/core/unfold_composite.py
+++ b/src/bssunfold/core/unfold_composite.py
@@ -42,6 +42,7 @@ METHOD_DISPATCH: Dict[str, str] = {
     "interpret": "unfold_interpret",
     "maeo_ensemble": "unfold_maeo",
     "mystic": "unfold_mystic",
+    "mystic_hybrid": "unfold_mystic_hybrid",
     "cs": "unfold_cs",
     "scip": "unfold_scip",
     "docplex": "unfold_docplex",
@@ -54,7 +55,7 @@ DEFAULT_BIN_METHODS: Dict[str, List[str]] = {
     "very_soft": ["tsvd", "bayes", "cvxpy", "statreg", "lanczos"],
     "soft": ["mlem", "landweber", "bayes_spline", "gravel", "qpsolvers"],
     "intermediate": ["cvxpy", "qpsolvers", "hybrid_parametric", "parametric2"],
-    "hard": ["genetic", "interpret", "maeo_ensemble", "mystic", "cs"],
+    "hard": ["genetic", "interpret", "maeo_ensemble", "mystic", "mystic_hybrid", "cs"],
     "very_hard": ["scip", "docplex", "epic", "cs", "interpret"],
 }
 
@@ -86,6 +87,7 @@ DEFAULT_ENSEMBLE_WEIGHTS: Dict[str, float] = {
     "interpret": 0.8,
     "maeo_ensemble": 0.8,
     "mystic": 0.8,
+    "mystic_hybrid": 0.85,
     "cs": 0.8,
     "scip": 0.8,
     "docplex": 0.8,

--- a/src/bssunfold/core/unfold_mystic.py
+++ b/src/bssunfold/core/unfold_mystic.py
@@ -5,6 +5,11 @@ wrapper with various regularization selection methods. The optimization is
 performed with the ``mystic`` constrained-optimization framework
 (https://pypi.org/project/mystic/), using a direct-search solver on the
 penalized least-squares objective.
+
+Additionally, a two-stage hybrid solver (``solve_mystic_hybrid`` / 
+``unfold_mystic_hybrid``) is provided that first uses ``diffev2`` for
+global exploration and then refines the result with ``fmin_powell`` for
+precise local convergence.
 """
 
 import warnings
@@ -16,7 +21,12 @@ from ._base_unfolder import _build_system, make_solve_wrapper, run_unfolding
 from ._matrix_utils import create_derivative_matrix
 from .regularization import select_regularization_parameter
 
-__all__ = ["solve_mystic", "unfold_mystic"]
+__all__ = [
+    "solve_mystic",
+    "unfold_mystic",
+    "solve_mystic_hybrid",
+    "unfold_mystic_hybrid",
+]
 
 # Supported mystic minimal-interface solvers
 _SUPPORTED_SOLVERS = ("fmin", "fmin_powell", "diffev", "diffev2")
@@ -323,6 +333,414 @@ def unfold_mystic(
             "selected_regularization": float(selected_lambda),
             "smoothness_order": smoothness_order,
             "smoothness_weight": smoothness_weight,
+        },
+        calculate_errors=calculate_errors,
+        noise_level=noise_level,
+        n_montecarlo=n_montecarlo,
+        random_state=random_state,
+        save_result=save_result,
+    )
+
+
+def solve_mystic_hybrid(
+    A: np.ndarray,
+    b: np.ndarray,
+    alpha: float,
+    norm: int = 2,
+    x0: Optional[np.ndarray] = None,
+    global_solver: str = "diffev2",
+    local_solver: str = "fmin_powell",
+    global_maxiter: Optional[int] = None,
+    global_maxfun: Optional[int] = None,
+    local_maxiter: Optional[int] = None,
+    local_maxfun: Optional[int] = None,
+    npop: Optional[int] = None,
+    smoothness_order: int = 0,
+    smoothness_weight: float = 1.0,
+) -> np.ndarray:
+    """Two-stage hybrid solver: global search then local refinement.
+
+    Stage 1 runs a population-based solver (default ``diffev2``) with
+    automatically derived bounds to locate the basin of the global minimum.
+    Stage 2 feeds that result as ``x0`` into a local direct-search solver
+    (default ``fmin_powell``) for precise convergence.
+
+    This combines the robustness of global exploration with the accuracy
+    of local optimization, which is a widely used practical strategy for
+    ill-posed inverse problems like spectrum unfolding.
+
+    Parameters
+    ----------
+    A : np.ndarray
+        Response matrix (m x n).
+    b : np.ndarray
+        Measurement vector (m,).
+    alpha : float
+        Regularization parameter.
+    norm : int, optional
+        Norm type (1 for L1, 2 for L2), default: 2.
+    x0 : np.ndarray, optional
+        Initial values for the global stage. Defaults to the zero vector.
+    global_solver : str, optional
+        Population-based solver for stage 1. Must be ``'diffev'`` or
+        ``'diffev2'`` (default: ``'diffev2'``).
+    local_solver : str, optional
+        Local solver for stage 2. Must be ``'fmin'`` or ``'fmin_powell'``
+        (default: ``'fmin_powell'``).
+    global_maxiter : int, optional
+        Maximum iterations for the global stage. Defaults to 200.
+    global_maxfun : int, optional
+        Maximum function evaluations for the global stage.
+        Defaults to ``10 * n * 20`` where *n* is the number of energy bins.
+    local_maxiter : int, optional
+        Maximum iterations for the local stage. Defaults to 2000.
+    local_maxfun : int, optional
+        Maximum function evaluations for the local stage.
+        Defaults to 20000.
+    npop : int, optional
+        Population size for the global stage. Defaults to
+        ``min(10 * n, 200)`` where *n* is the number of energy bins.
+    smoothness_order : int, optional
+        Smoothness constraint order (0, 1, or 2), default: 0.
+    smoothness_weight : float, optional
+        Weight for the smoothness term, default: 1.0.
+
+    Returns
+    -------
+    np.ndarray
+        Unfolded spectrum (n,). Returns a zero vector if both stages fail.
+    """
+    try:
+        from mystic.penalty import quadratic_inequality
+    except ImportError as e:
+        raise ImportError(
+            "mystic is required for solve_mystic_hybrid. "
+            "Install with: pip install mystic"
+        ) from e
+
+    # --- Validate solver choices ---
+    _GLOBAL_SOLVERS = ("diffev", "diffev2")
+    _LOCAL_SOLVERS = ("fmin", "fmin_powell")
+
+    if global_solver not in _GLOBAL_SOLVERS:
+        warnings.warn(
+            f"Global solver '{global_solver}' is not population-based. "
+            f"Supported: {_GLOBAL_SOLVERS}. Falling back to 'diffev2'."
+        )
+        global_solver = "diffev2"
+
+    if local_solver not in _LOCAL_SOLVERS:
+        warnings.warn(
+            f"Local solver '{local_solver}' is not a direct-search solver. "
+            f"Supported: {_LOCAL_SOLVERS}. Falling back to 'fmin_powell'."
+        )
+        local_solver = "fmin_powell"
+
+    n = A.shape[1]
+
+    # --- Derivative matrix for smoothness ---
+    L = None
+    if smoothness_order in (1, 2):
+        L = create_derivative_matrix(n, smoothness_order)
+
+    # --- Objective function (shared by both stages) ---
+    def cost(x: np.ndarray) -> float:
+        x = np.asarray(x, dtype=float)
+        residual = A @ x - b
+        value = float(np.dot(residual, residual))
+        if norm == 2:
+            value += alpha * float(np.dot(x, x))
+        elif norm == 1:
+            value += alpha * float(np.sum(np.abs(x)))
+        else:
+            raise ValueError(f"Unsupported norm type: {norm}")
+        if L is not None:
+            value += alpha * smoothness_weight * float(
+                np.dot(L @ x, L @ x)
+            )
+        return value
+
+    @quadratic_inequality(_nonneg_condition)
+    def penalty(x: np.ndarray) -> float:
+        return 0.0
+
+    # --- Default limits ---
+    if global_maxiter is None:
+        global_maxiter = 200
+    if global_maxfun is None:
+        global_maxfun = 10 * n * 20
+    if local_maxiter is None:
+        local_maxiter = 2000
+    if local_maxfun is None:
+        local_maxfun = 20000
+    if npop is None:
+        npop = min(10 * n, 200)
+
+    x0_arr = np.zeros(n)
+    if x0 is not None:
+        x0_arr = np.maximum(np.asarray(x0, dtype=float), 0)
+
+    # ============================================================
+    # Stage 1: Global search with population-based solver
+    # ============================================================
+    global_cost = float("inf")
+    x_global = np.zeros(n)
+
+    try:
+        solver_func = _solver_function(global_solver)
+        bounds = _build_bounds(A, b, x0_arr)
+        x_global = np.asarray(
+            solver_func(
+                cost,
+                x0_arr,
+                bounds=bounds,
+                penalty=penalty,
+                maxiter=global_maxiter,
+                maxfun=global_maxfun,
+                npop=npop,
+                disp=0,
+            ),
+            dtype=float,
+        )
+        global_cost = cost(x_global)
+    except Exception as exc:
+        warnings.warn(
+            f"Hybrid stage 1 (global, solver='{global_solver}') failed: "
+            f"{exc}. Attempting local refinement from zero vector."
+        )
+
+    # ============================================================
+    # Stage 2: Local refinement with direct-search solver
+    # ============================================================
+    x_local = np.maximum(x_global, 0.0)  # ensure non-negative start
+
+    try:
+        solver_func = _solver_function(local_solver)
+        x_local = np.asarray(
+            solver_func(
+                cost,
+                x_local,
+                penalty=penalty,
+                maxiter=local_maxiter,
+                maxfun=local_maxfun,
+                disp=0,
+            ),
+            dtype=float,
+        )
+        local_cost = cost(x_local)
+    except Exception as exc:
+        warnings.warn(
+            f"Hybrid stage 2 (local, solver='{local_solver}') failed: "
+            f"{exc}. Returning global stage result."
+        )
+        return np.maximum(x_global, 0.0)
+
+    # Return the best of the two stages
+    if local_cost <= global_cost:
+        return np.maximum(x_local, 0.0)
+    else:
+        warnings.warn(
+            "Hybrid local stage did not improve upon global result. "
+            f"Global cost: {global_cost:.6e}, local cost: {local_cost:.6e}. "
+            "Returning global stage result."
+        )
+        return np.maximum(x_global, 0.0)
+
+
+def unfold_mystic_hybrid(
+    detector_names: List[str],
+    n_energy_bins: int,
+    E_MeV: np.ndarray,
+    sensitivities: Dict[str, np.ndarray],
+    cc_icrp116: Dict[str, np.ndarray],
+    save_result_callback,
+    readings: Dict[str, float],
+    initial_spectrum: Optional[np.ndarray] = None,
+    regularization: float = 1e-4,
+    norm: int = 2,
+    global_solver: str = "diffev2",
+    local_solver: str = "fmin_powell",
+    global_maxiter: Optional[int] = None,
+    global_maxfun: Optional[int] = None,
+    local_maxiter: Optional[int] = None,
+    local_maxfun: Optional[int] = None,
+    npop: Optional[int] = None,
+    calculate_errors: bool = False,
+    noise_level: float = 0.01,
+    n_montecarlo: int = 100,
+    save_result: bool = False,
+    regularization_method: str = "manual",
+    noise_var: Optional[float] = None,
+    smoothness_order: int = 0,
+    smoothness_weight: float = 1.0,
+    random_state: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Two-stage hybrid unfolding: global search + local refinement.
+
+    Stage 1 uses a population-based solver (``diffev2`` by default) with
+    automatically derived bounds to robustly locate the basin of the
+    global minimum. Stage 2 feeds that result as ``x0`` into a local
+    direct-search solver (``fmin_powell`` by default) for precise final
+    convergence. This combines the robustness of global optimization
+    with the accuracy of local optimization.
+
+    Parameters
+    ----------
+    detector_names : List[str]
+        Names of available detectors.
+    n_energy_bins : int
+        Number of energy bins.
+    E_MeV : np.ndarray
+        Energy grid.
+    sensitivities : Dict[str, np.ndarray]
+        Detector sensitivity arrays.
+    cc_icrp116 : Dict[str, np.ndarray]
+        ICRP-116 conversion coefficients.
+    save_result_callback : callable
+        Callback to save result to history.
+    readings : Dict[str, float]
+        Detector readings.
+    initial_spectrum : np.ndarray, optional
+        Initial spectrum guess for the global stage.
+    regularization : float, optional
+        Regularization parameter, default: 1e-4.
+    norm : int, optional
+        Norm type (1 for L1, 2 for L2), default: 2.
+    global_solver : str, optional
+        Population-based solver for stage 1 (``'diffev'`` or ``'diffev2'``),
+        default: ``'diffev2'``.
+    local_solver : str, optional
+        Local solver for stage 2 (``'fmin'`` or ``'fmin_powell'``),
+        default: ``'fmin_powell'``.
+    global_maxiter : int, optional
+        Maximum iterations for the global stage (default: 200).
+    global_maxfun : int, optional
+        Maximum function evaluations for the global stage.
+    local_maxiter : int, optional
+        Maximum iterations for the local stage (default: 2000).
+    local_maxfun : int, optional
+        Maximum function evaluations for the local stage.
+    npop : int, optional
+        Population size for the global stage.
+    calculate_errors : bool, optional
+        If True, calculate Monte-Carlo uncertainty, default: False.
+    noise_level : float, optional
+        Noise level for Monte-Carlo, default: 0.01.
+    n_montecarlo : int, optional
+        Number of Monte-Carlo samples, default: 100.
+    save_result : bool, optional
+        Save result to history, default: False.
+    regularization_method : str, optional
+        Method for selecting regularization parameter.
+    noise_var : float, optional
+        Noise variance for discrepancy principle ('dp' method).
+    smoothness_order : int, optional
+        Smoothness constraint order (0, 1, or 2), default: 0.
+    smoothness_weight : float, optional
+        Weight for smoothness term, default: 1.0.
+    random_state : int, optional
+        Random seed for reproducibility.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Unfolding results including spectrum, residuals, and metadata.
+    """
+    A, b, _ = _build_system(readings, detector_names, sensitivities)
+
+    # --- Regularization parameter selection (same logic as unfold_mystic) ---
+    if regularization_method == "manual":
+        alpha = regularization
+        selected_lambda = alpha
+    elif regularization_method == "cosine":
+        if initial_spectrum is None:
+            raise ValueError(
+                "For 'cosine' regularization method, "
+                "initial_spectrum must be provided."
+            )
+        if norm != 2:
+            warnings.warn(
+                f"Cosine regularization selection method assumes L2 "
+                f"norm, but norm={norm} was requested. Using L2 for "
+                f"selection."
+            )
+        initial_spectrum_norm = np.maximum(initial_spectrum, 0)
+        if len(initial_spectrum_norm) != n_energy_bins:
+            raise ValueError(
+                f"Initial spectrum length ({len(initial_spectrum)}) "
+                f"must match number of energy bins ({n_energy_bins})"
+            )
+        selected_lambda = select_regularization_parameter(
+            A, b, method="cosine", initial_spectrum=initial_spectrum_norm
+        )
+        alpha = selected_lambda
+        print(
+            f"Selected regularization (method=cosine): {selected_lambda:.3e}"
+        )
+    else:
+        if norm != 2:
+            warnings.warn(
+                f"Automatic regularization selection methods assume L2 "
+                f"norm, but norm={norm} was requested. Using L2 for "
+                f"selection."
+            )
+        try:
+            selected_lambda = select_regularization_parameter(
+                A, b, method=regularization_method, noise_var=noise_var
+            )
+        except Exception as e:
+            raise ValueError(
+                f"Regularization selection failed: {e}. "
+                "Consider using manual regularization."
+            ) from e
+        alpha = selected_lambda
+        print(
+            f"Selected regularization (method={regularization_method}): "
+            f"{selected_lambda:.3e}"
+        )
+
+    x0_default = np.zeros(n_energy_bins)
+
+    return run_unfolding(
+        detector_names=detector_names,
+        n_energy_bins=n_energy_bins,
+        E_MeV=E_MeV,
+        sensitivities=sensitivities,
+        cc_icrp116=cc_icrp116,
+        save_result_callback=save_result_callback,
+        readings=readings,
+        initial_spectrum=initial_spectrum,
+        default_initial=x0_default,
+        solve_func=make_solve_wrapper(
+            solve_mystic_hybrid,
+            alpha=alpha,
+            norm=norm,
+            global_solver=global_solver,
+            local_solver=local_solver,
+            global_maxiter=global_maxiter,
+            global_maxfun=global_maxfun,
+            local_maxiter=local_maxiter,
+            local_maxfun=local_maxfun,
+            npop=npop,
+            smoothness_order=smoothness_order,
+            smoothness_weight=smoothness_weight,
+        ),
+        solve_kwargs={},
+        method_name=f"mystic_hybrid_{global_solver}_{local_solver}",
+        extra_output={
+            "norm": norm,
+            "global_solver": global_solver,
+            "local_solver": local_solver,
+            "regularization": regularization,
+            "regularization_method": regularization_method,
+            "selected_regularization": float(selected_lambda),
+            "smoothness_order": smoothness_order,
+            "smoothness_weight": smoothness_weight,
+            "global_maxiter": global_maxiter,
+            "global_maxfun": global_maxfun,
+            "local_maxiter": local_maxiter,
+            "local_maxfun": local_maxfun,
+            "npop": npop,
         },
         calculate_errors=calculate_errors,
         noise_level=noise_level,

--- a/src/bssunfold/core/unfold_mystic.py
+++ b/src/bssunfold/core/unfold_mystic.py
@@ -6,7 +6,7 @@ performed with the ``mystic`` constrained-optimization framework
 (https://pypi.org/project/mystic/), using a direct-search solver on the
 penalized least-squares objective.
 
-Additionally, a two-stage hybrid solver (``solve_mystic_hybrid`` / 
+Additionally, a two-stage hybrid solver (``solve_mystic_hybrid`` /
 ``unfold_mystic_hybrid``) is provided that first uses ``diffev2`` for
 global exploration and then refines the result with ``fmin_powell`` for
 precise local convergence.

--- a/tests/test_mystic.py
+++ b/tests/test_mystic.py
@@ -3,6 +3,8 @@
 The ``mystic`` package is an optional backend installed in the dev group.
 These tests cover the ``solve_mystic`` core solver and the ``unfold_mystic``
 wrapper exposed both on the ``Detector`` class and as a module-level function.
+Tests for the two-stage hybrid solver (``solve_mystic_hybrid`` / 
+``unfold_mystic_hybrid``) are also included.
 """
 
 from unittest.mock import patch
@@ -285,6 +287,252 @@ def test_unfold_combined_mystic(detector, readings):
             {
                 "method": "mystic",
                 "params": {"maxiter": 200, "save_result": False},
+            }
+        ],
+        verbose=False,
+    )
+    assert "spectrum" in result
+    assert np.all(result["spectrum"] >= 0)
+
+
+# ============================================================
+# Hybrid solver tests (solve_mystic_hybrid / unfold_mystic_hybrid)
+# ============================================================
+
+
+def test_unfold_mystic_hybrid_basic(detector, readings):
+    """Basic hybrid call returns a standardized result."""
+    result = detector.unfold_mystic_hybrid(
+        readings,
+        regularization=1e-3,
+        global_maxiter=30,
+        global_maxfun=500,
+        local_maxiter=200,
+        local_maxfun=2000,
+        save_result=False,
+    )
+
+    assert isinstance(result, dict)
+    assert "energy" in result
+    assert "spectrum" in result
+    assert "residual_norm" in result
+    assert "method" in result
+    assert "mystic_hybrid" in result["method"]
+    assert isinstance(result["energy"], np.ndarray)
+    assert isinstance(result["spectrum"], np.ndarray)
+    assert isinstance(result["residual_norm"], float)
+    assert len(result["spectrum"]) == detector.n_energy_bins
+    assert np.all(result["spectrum"] >= 0)
+    assert result["global_solver"] == "diffev2"
+    assert result["local_solver"] == "fmin_powell"
+    assert result["selected_regularization"] == pytest.approx(1e-3)
+
+
+def test_unfold_mystic_hybrid_diffev_fmin(detector, readings):
+    """Hybrid with diffev + fmin solver combination."""
+    result = detector.unfold_mystic_hybrid(
+        readings,
+        global_solver="diffev",
+        local_solver="fmin",
+        global_maxiter=20,
+        global_maxfun=500,
+        local_maxiter=200,
+        local_maxfun=2000,
+        save_result=False,
+    )
+    assert "mystic_hybrid_diffev_fmin" in result["method"]
+    assert np.all(result["spectrum"] >= 0)
+
+
+def test_solve_mystic_hybrid_returns_array(detector, readings):
+    """Core solve_mystic_hybrid returns raw ndarray."""
+    from bssunfold.core.unfold_mystic import solve_mystic_hybrid
+
+    selected = [name for name in detector.detector_names if name in readings]
+    A = np.array([detector.sensitivities[name] for name in selected])
+    b = np.array([readings[name] for name in selected], dtype=float)
+
+    spectrum = solve_mystic_hybrid(
+        A,
+        b,
+        alpha=1e-3,
+        global_maxiter=20,
+        global_maxfun=500,
+        local_maxiter=200,
+        local_maxfun=2000,
+    )
+    assert isinstance(spectrum, np.ndarray)
+    assert spectrum.shape == (detector.n_energy_bins,)
+    assert np.all(spectrum >= -1e-6)
+
+
+def test_solve_mystic_hybrid_import_error():
+    """Missing mystic raises a helpful ImportError."""
+    from bssunfold.core.unfold_mystic import solve_mystic_hybrid
+
+    A = np.eye(3)
+    b = np.ones(3)
+
+    with block_import("mystic"):
+        with pytest.raises(ImportError, match="mystic is required"):
+            solve_mystic_hybrid(A, b, alpha=1e-3)
+
+
+def test_unfold_mystic_hybrid_unknown_global_solver(detector, readings):
+    """Unknown global solver falls back to diffev2 with warning."""
+    with pytest.warns(UserWarning, match="not population-based"):
+        result = detector.unfold_mystic_hybrid(
+            readings,
+            global_solver="fmin_powell",
+            global_maxiter=10,
+            global_maxfun=200,
+            local_maxiter=100,
+            local_maxfun=1000,
+            save_result=False,
+        )
+    assert np.all(result["spectrum"] >= 0)
+
+
+def test_unfold_mystic_hybrid_unknown_local_solver(detector, readings):
+    """Unknown local solver falls back to fmin_powell with warning."""
+    with pytest.warns(UserWarning, match="not a direct-search"):
+        result = detector.unfold_mystic_hybrid(
+            readings,
+            local_solver="diffev2",
+            global_maxiter=10,
+            global_maxfun=200,
+            local_maxiter=100,
+            local_maxfun=1000,
+            save_result=False,
+        )
+    assert np.all(result["spectrum"] >= 0)
+
+
+def test_unfold_mystic_hybrid_norm1(detector, readings):
+    """L1 regularization norm is supported by hybrid solver."""
+    result = detector.unfold_mystic_hybrid(
+        readings,
+        norm=1,
+        regularization=1e-3,
+        global_maxiter=10,
+        global_maxfun=200,
+        local_maxiter=100,
+        local_maxfun=1000,
+        save_result=False,
+    )
+    assert result["norm"] == 1
+    assert np.all(result["spectrum"] >= 0)
+
+
+def test_unfold_mystic_hybrid_smoothness(detector, readings):
+    """Smoothness constraints work with hybrid solver."""
+    for order in (1, 2):
+        result = detector.unfold_mystic_hybrid(
+            readings,
+            smoothness_order=order,
+            smoothness_weight=0.5,
+            global_maxiter=10,
+            global_maxfun=200,
+            local_maxiter=100,
+            local_maxfun=1000,
+            save_result=False,
+        )
+        assert result["smoothness_order"] == order
+        assert result["smoothness_weight"] == 0.5
+        assert np.all(result["spectrum"] >= 0)
+
+
+def test_unfold_mystic_hybrid_with_errors(detector, readings):
+    """Monte-Carlo uncertainty works with hybrid solver."""
+    result = detector.unfold_mystic_hybrid(
+        readings,
+        regularization=1e-3,
+        calculate_errors=True,
+        n_montecarlo=3,
+        global_maxiter=10,
+        global_maxfun=200,
+        local_maxiter=100,
+        local_maxfun=1000,
+        save_result=False,
+    )
+    assert "spectrum_uncert_mean" in result
+    assert "spectrum_uncert_std" in result
+    assert len(result["spectrum_uncert_mean"]) == detector.n_energy_bins
+
+
+def test_unfold_mystic_hybrid_save_result(detector, readings):
+    """save_result=True stores result in history."""
+    detector.unfold_mystic_hybrid(
+        readings,
+        global_maxiter=10,
+        global_maxfun=200,
+        local_maxiter=100,
+        local_maxfun=1000,
+        save_result=True,
+    )
+    assert len(detector.results_history) == 1
+    latest = detector.results_history[max(detector.results_history.keys())]
+    assert "mystic_hybrid" in latest["method"]
+
+
+def test_unfold_mystic_hybrid_reg_methods(detector, readings, initial):
+    """Automatic regularization selection works with hybrid."""
+    result = detector.unfold_mystic_hybrid(
+        readings,
+        regularization_method="lcurve",
+        global_maxiter=10,
+        global_maxfun=200,
+        local_maxiter=100,
+        local_maxfun=1000,
+        save_result=False,
+    )
+    assert "spectrum" in result
+    assert result["regularization_method"] == "lcurve"
+    assert result["selected_regularization"] > 0
+
+
+def test_unfold_mystic_hybrid_cosine_no_initial(detector, readings):
+    """Cosine selection without initial spectrum raises ValueError."""
+    with pytest.raises(ValueError, match="initial_spectrum must be provided"):
+        detector.unfold_mystic_hybrid(
+            readings,
+            regularization_method="cosine",
+            global_maxiter=10,
+            local_maxiter=100,
+            save_result=False,
+        )
+
+
+def test_core_exports_hybrid():
+    """solve_mystic_hybrid and unfold_mystic_hybrid are exported."""
+    from bssunfold.core import solve_mystic_hybrid, unfold_mystic_hybrid
+
+    assert solve_mystic_hybrid is not None
+    assert unfold_mystic_hybrid is not None
+
+
+def test_unfold_combined_mystic_hybrid(detector, readings):
+    """'mystic_hybrid' can be used in a combined unfolding pipeline."""
+    from bssunfold.core.unfold_combined import unfold_combined
+
+    result = unfold_combined(
+        detector_names=detector.detector_names,
+        n_energy_bins=detector.n_energy_bins,
+        E_MeV=detector.E_MeV,
+        sensitivities=detector.sensitivities,
+        cc_icrp116=detector._get_interpolated_cc(),
+        save_result_callback=detector._save_result,
+        readings=readings,
+        pipeline=[
+            {
+                "method": "mystic_hybrid",
+                "params": {
+                    "global_maxiter": 10,
+                    "global_maxfun": 200,
+                    "local_maxiter": 100,
+                    "local_maxfun": 1000,
+                    "save_result": False,
+                },
             }
         ],
         verbose=False,

--- a/tests/test_mystic.py
+++ b/tests/test_mystic.py
@@ -3,7 +3,7 @@
 The ``mystic`` package is an optional backend installed in the dev group.
 These tests cover the ``solve_mystic`` core solver and the ``unfold_mystic``
 wrapper exposed both on the ``Detector`` class and as a module-level function.
-Tests for the two-stage hybrid solver (``solve_mystic_hybrid`` / 
+Tests for the two-stage hybrid solver (``solve_mystic_hybrid`` /
 ``unfold_mystic_hybrid``) are also included.
 """
 


### PR DESCRIPTION
Add solve_mystic_hybrid and unfold_mystic_hybrid that combine a global population-based search (diffev2 by default) with local direct-search refinement (fmin_powell by default) for robust and accurate unfolding.

Stage 1 (global) locates the basin of the global minimum using automatically derived bounds. Stage 2 (local) refines the solution for precise convergence. The best of both stages is returned.

- solve_mystic_hybrid(): core two-stage solver
- unfold_mystic_hybrid(): full wrapper with regularization selection
- Detector.unfold_mystic_hybrid(): instance method
- Registered as 'mystic_hybrid' in cascade, combined, composite pipelines
- 14 new tests (all passing)